### PR TITLE
fix: Note content corruption on restart

### DIFF
--- a/editor-web/src/editor.js
+++ b/editor-web/src/editor.js
@@ -1525,6 +1525,7 @@ window.dumpTree = function () {
 
 // Set the current note ID (called from Swift before loading content)
 window.setCurrentNoteId = function (id) {
+  clearTimeout(debounceTimer); // prevent stale debounce from writing to the wrong noteId
   currentNoteId = id;
 };
 


### PR DESCRIPTION
## Problem

After an OS restart (or app relaunch), inactive notes have their content replaced with the active note's content. The first note's content gets replicated to the others.

## Root Cause

The `contentChanged` debounce timer (300ms in JS) captures `currentNoteId` at **fire time**, not at schedule time. When a note switch occurs between scheduling and firing:

1. User edits note A → debounce timer starts (300ms)
2. User clicks note B → Swift queues: `serializeState()`, `setCurrentNoteId('B')`, `restoreState(B)`
3. JS executes `setCurrentNoteId('B')` → `currentNoteId = B`
4. **Debounce fires** → sends A's content with `noteId = B` → overwrites note B with A's content
5. `restoreState(B)` executes → clears debounce (too late), loads B's correct content from `stateCache`

The corruption is **invisible during the session** because the in-memory `stateCache` still holds B's correct content. But on next launch (or after OS restart), `stateCache` is empty and B loads from the corrupted persisted data — showing A's content.

## Fix

Clear the debounce timer in `setCurrentNoteId()`. This is safe because `serializeState()` → `cacheSerializedState()` already persists the old note's content before `setCurrentNoteId` is called in every note-switch path.

```javascript
window.setCurrentNoteId = function (id) {
  clearTimeout(debounceTimer);
  currentNoteId = id;
};
```

## Changed files

- `editor-web/src/editor.js` — 1 line added in `setCurrentNoteId()`